### PR TITLE
Add 1 year limit to notification timestamp trigger.

### DIFF
--- a/IDL.md
+++ b/IDL.md
@@ -28,4 +28,4 @@ partial interface Notification {
 }
 ```
 
-The [create a notification](https://notifications.spec.whatwg.org/#create-a-notification) algorithm will be amended to throw a `TypeError` exception when a `showTrigger` has been provided, but not a `serviceWorkerRegistration`. This removes the ability to use _notification triggers_ for non-persistent notifications, which inherently are tied to the lifetime of the document.
+The [create a notification](https://notifications.spec.whatwg.org/#create-a-notification) algorithm will be amended to throw a `TypeError` exception when a `showTrigger` has been provided, but not a `serviceWorkerRegistration`. This removes the ability to use _notification triggers_ for non-persistent notifications, which inherently are tied to the lifetime of the document. It will also throw a `TypeError` exception when a `TimestampTrigger` is provided that is more than 1 year ahead of now, calculated via `Date.now() + MAX_TRIGGER_FUTURE > timestamp` where `MAX_TRIGGER_FUTURE` is defined as `367 * 24 * 60 * 60 * 1000`. 367 days are chosen to account for leap years and seconds.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Web developers have the ability to display notifications using the [Notification
 
 **Notification Triggers** are a mechanism for preparing notifications that are to be shown when certain conditions are met. The _trigger_ could be time-based, location-based or otherwise—for this explainer, we'll focus on time-based triggers.
 
-This makes it possible to prepare notifications to be displayed at a particular time without involving the server, and also improves reliability by removing the dependency on network connectivity. This can be essential for the user experience of certain types of web applications, for example calendars.
+This makes it possible to prepare notifications to be displayed at a particular time without involving the server, and also improves reliability by removing the dependency on network connectivity. This can be essential for the user experience of certain types of web applications, for example calendars. To reduce misuse of this API, a notification can only be scheduled for up to 1 year in advance.
 
 ## Why do we care?
 * The Push API is not reliable for triggering notifications which must be shown at a particular time. The ability to receive messages depends on the device's connectivity, and features such as _deep sleep_ may further delay delivery. An example where this is important are notifications reminding you of a 5 AM departure time to the airport.


### PR DESCRIPTION
This adds the maximum time a notification can be scheduled for in the future.